### PR TITLE
Use http paths for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake/modules"]
 	path = cmake/modules
-	url = git@github.com:BoostCMake/cmake_modules.git
+	url = https://github.com/NilFoundation/actor-containers.git


### PR DESCRIPTION
Required for building proof-market-toolchain in CI.